### PR TITLE
add spec .only ban

### DIFF
--- a/tslint.js
+++ b/tslint.js
@@ -5,6 +5,12 @@ module.exports = {
         path.join(path.dirname(require.resolve('tslint-eslint-rules')), 'dist/rules')
     ],
     rules: {
+        "ban": [
+            true,
+            "eval",
+            { "name": ["it", "only"], "message": "don't focus tests" },
+            { "name": ["describe", "only"], "message": "don't focus tests" }
+        ],
         'no-namespace': [
             true,
             'allow-declarations'

--- a/tslint.js
+++ b/tslint.js
@@ -9,7 +9,9 @@ module.exports = {
             true,
             "eval",
             { "name": ["it", "only"], "message": "don't focus tests" },
-            { "name": ["describe", "only"], "message": "don't focus tests" }
+            { "name": ["describe", "only"], "message": "don't focus tests" },
+            { "name": ["fdescribe"], "message": "don't focus tests" },
+            { "name": ["fit"], "message": "don't focus tests" }
         ],
         'no-namespace': [
             true,


### PR DESCRIPTION
This pr adds a lint rule around spec files that contain a `it.only` or `describe.only` to remove the ability to commit "focused" tests. If these are committed, only the focused specs will be run which would likely hide regressions.